### PR TITLE
fix counting time when paused

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -143,6 +143,8 @@ impl GameState {
                         cnv.draw_strs(&PAUSE.to_vec(), (7, 13), BORDER_COLOR, &Reset); // Drawing the pause text
                         sleep(Duration::from_millis(interval_ms));
                     }
+                    // prevent counting the paused time as elapsed time
+                    last_time = Instant::now();
                 }
             }
             self.draw(cnv, hs_disp);


### PR DESCRIPTION
There is a bug where a block can be glitched below the frame when pausing the game before the block lands.

Steps to reproduce:
1. set the initial game speed to 5.0 (the bug only appears in faster game speed): `const INITIAL_FALL_SPD: f32 = 5.0;`
2. run the game, pausing it when the block is one block away from landing: <img width="492" height="452" alt="Screenshot_20260317_150831" src="https://github.com/user-attachments/assets/af613fee-c643-4da1-b67e-bb649247665a" />
3. wait a few seconds, then unpause it, the block will glitch out of the game, causing a crash: <img width="937" height="552" alt="Screenshot_20260317_150844" src="https://github.com/user-attachments/assets/d2813675-3345-42dc-9743-49b93cec4b3b" />


You might need to try this a few times before triggering the bug. The problem is in the `play` method, the time spent in pause is counted in `delta_time_ms`, which is passed into the `update` method. I fixed this by setting `last_time` to the current instant after unpausing the game. I tested this fix by playing for some time and using the steps above, and it seems to work fine.